### PR TITLE
Browser compatibility without shimming global

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-var NativeProgressEvent = global.ProgressEvent;
+var NativeProgressEvent = typeof global !== 'undefined' && global.ProgressEvent;
 var useNative = !!NativeProgressEvent;
 
 try {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
-var NativeProgressEvent = typeof global !== 'undefined' && global.ProgressEvent;
+var NativeProgressEvent = (typeof global !== 'undefined' && global.ProgressEvent) ||
+                          (typeof window !== 'undefined' && window.ProgressEvent);
 var useNative = !!NativeProgressEvent;
 
 try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progress-event",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Cross-browser `ProgressEvent` constructor",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I'm currently working on a pull request within `wp-calypso` where I am trying to free it of as many nodejs polyfills and shims as possible: https://github.com/Automattic/wp-calypso/pull/22630.

One issue I just ran into is that `wp-calypso` depends on `wpcom-rest-proxy` which depends on this package. This package calls `global.ProgressEvent` even though global does not exist within browsers (and was being polyfilled by webpack).